### PR TITLE
Fix: Update README, license consistency, and Helm chart configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This separation of concerns ensures scalability, resilience, and aligns with Kub
 1.  Add the Helm chart repository (replace with your actual repo URL once published):
 
     ```/dev/null/helm-install.sh#L1-1
-    helm repo add iperf3-monitor https://your-github-org.github.io/iperf3-monitor/
+    helm repo add iperf3-monitor https://malarinv.github.io/iperf3-monitor/
     ```
 
 2.  Update your Helm repositories:
@@ -78,7 +78,7 @@ exporter:
   # -- Configuration for the exporter container image.
   image:
     # -- The container image repository for the exporter.
-    repository: ghcr.io/my-org/iperf3-prometheus-exporter # Replace with your repo URL
+    repository: ghcr.io/malarinv/iperf3-monitor
     # -- The container image tag for the exporter. If not set, the chart's appVersion is used.
     tag: ""
     # -- The image pull policy for the exporter container.
@@ -430,8 +430,4 @@ The project includes a GitHub Actions workflow (`.github/workflows/release.yml`)
 
 ## License
 
-This project is licensed under the terms defined in the `LICENSE` file.
-
-```iperf3-monitor/LICENSE
-This project is currently unlicensed. Please see the project's documentation or repository for licensing information when it becomes available.
-```
+This project is licensed under the GNU Affero General Public License v3. See the `LICENSE` file for details.

--- a/charts/iperf3-monitor/Chart.yaml
+++ b/charts/iperf3-monitor/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - kubernetes
   - prometheus
   - grafana
-home: https://github.com/malarinv/iperf3-monitor # Replace with your repo URL
+home: https://github.com/malarinv/iperf3-monitor
 sources:
-  - https://github.com/malarinv/iperf3-monitor # Replace with your repo URL
+  - https://github.com/malarinv/iperf3-monitor
 maintainers:
-  - name: Malar Invention # Replace with your name
-    email: malarkannan.invention@gmail.com # Replace with your email
+  - name: Malar Invention
+    email: malarkannan.invention@gmail.com
 icon: https://raw.githubusercontent.com/malarinv/iperf3-monitor/main/icon.png # Optional icon URL
 annotations:
   artifacthub.io/changes: |

--- a/charts/iperf3-monitor/values.yaml
+++ b/charts/iperf3-monitor/values.yaml
@@ -12,7 +12,7 @@ exporter:
   # -- Configuration for the exporter container image.
   image:
     # -- The container image repository for the exporter.
-    repository: ghcr.io/malarinv/iperf3-prometheus-exporter # Replace with your repo URL
+    repository: ghcr.io/malarinv/iperf3-monitor
     # -- The container image tag for the exporter. If not set, the chart's appVersion is used.
     tag: ""
     # -- The image pull policy for the exporter container.


### PR DESCRIPTION
This commit addresses several issues to improve repository accuracy and CI reliability:

1.  **README.md Updates:**
    *   I corrected the Helm repository URL to `https://malarinv.github.io/iperf3-monitor/`.
    *   I updated the default exporter image name to `ghcr.io/malarinv/iperf3-monitor` in examples.
    *   I revised the License section to accurately reflect the AGPLv3 license present in the `LICENSE` file, removing contradictory statements.

2.  **License Consistency:**
    *   I confirmed `LICENSE` file contains AGPLv3. README now correctly refers to it.

3.  **Helm Chart Adjustments:**
    *   `charts/iperf3-monitor/Chart.yaml`: I removed placeholder comments for clarity. Versioning is handled by the release workflow.
    *   `charts/iperf3-monitor/values.yaml`: I updated `exporter.image.repository` to `ghcr.io/malarinv/iperf3-monitor` to match the CI build image name.

4.  **CI Workflow Verification:**
    *   I verified that `.github/workflows/release.yml` correctly uses `yq` to set chart versions from Git tags and publishes to the correct GitHub Pages URL. This should prevent the previously noted `chart.metadata.version is required` error, which was associated with an older version of the release workflow.

These changes ensure that the documentation is up-to-date, the Helm chart defaults are correct, and the CI pipeline for chart publishing is robust.