### PR TITLE
Fix: Final correction for yq command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
       - name: Set Chart Version from Tag
         run: |
           VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
-          yq e -i '.version = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
-          yq e -i '.appVersion = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
+          VERSION=$VERSION yq e -i '.version = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
+          VERSION=$VERSION yq e -i '.appVersion = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
           cat ./charts/iperf3-monitor/Chart.yaml # Optional: print updated Chart.yaml
 
       - name: Publish Helm chart


### PR DESCRIPTION
This commit implements a verified yq command syntax in the `.github/workflows/release.yml` file to ensure correct and reliable updating of Chart.yaml version and appVersion from Git tags.

The previous attempts faced issues with yq argument parsing and environment variable substitution. The new commands:
  VERSION=$VERSION yq e -i '.version = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
  VERSION=$VERSION yq e -i '.appVersion = strenv(VERSION)' ./charts/iperf3-monitor/Chart.yaml
were tested and confirmed to correctly modify
the Chart.yaml file as intended.

This change should resolve the issues where chart versions were being set incorrectly or to empty strings during the release process.