### PR TITLE
Feat: Add optional TrueCharts Prometheus Operator dependency

### DIFF
--- a/charts/iperf3-monitor/Chart.yaml
+++ b/charts/iperf3-monitor/Chart.yaml
@@ -27,4 +27,8 @@ dependencies:
   - name: kube-prometheus-stack # Example dependency if you package the whole stack
     version: ">=30.0.0" # Specify a compatible version range
     repository: https://prometheus-community.github.io/helm-charts
-    condition: serviceMonitor.enabled # Only include if ServiceMonitor is enabled (assuming Prometheus Operator)
+    condition: "serviceMonitor.enabled, !values.dependencies.useTrueChartsPrometheusOperator"
+  - name: prometheus-operator
+    version: "{{ .Values.dependencies.trueChartsPrometheusOperatorVersion }}"
+    repository: "{{ .Values.dependencies.trueChartsPrometheusOperatorRepository }}"
+    condition: "serviceMonitor.enabled, values.dependencies.useTrueChartsPrometheusOperator"

--- a/charts/iperf3-monitor/values.yaml
+++ b/charts/iperf3-monitor/values.yaml
@@ -118,3 +118,20 @@ networkPolicy:
   namespaceSelector: {}
   # -- Specify pod selectors if needed.
   podSelector: {}
+
+# -----------------------------------------------------------------------------
+# Dependency Configuration
+# -----------------------------------------------------------------------------
+dependencies:
+  # -- Set to true to use the TrueCharts Prometheus Operator instead of kube-prometheus-stack.
+  # This chart's ServiceMonitor resources require a Prometheus Operator to be functional.
+  # If serviceMonitor.enabled is true, one of these two dependencies will be pulled based on this flag.
+  useTrueChartsPrometheusOperator: false
+
+  # -- Repository for the TrueCharts Prometheus Operator.
+  # Only used if dependencies.useTrueChartsPrometheusOperator is true.
+  trueChartsPrometheusOperatorRepository: "oci://tccr.io/truecharts"
+
+  # -- Chart version for the TrueCharts Prometheus Operator.
+  # Only used if dependencies.useTrueChartsPrometheusOperator is true.
+  trueChartsPrometheusOperatorVersion: "8.11.1"


### PR DESCRIPTION
This commit introduces a configurable dependency for the Prometheus Operator, allowing you to choose between the standard kube-prometheus-stack and the TrueCharts version of prometheus-operator.

Changes include:

1.  **values.yaml:**
    *   Added a `dependencies` section with the following new values:
        *   `useTrueChartsPrometheusOperator` (boolean, default: false):
            Controls which operator dependency is enabled.
        *   `trueChartsPrometheusOperatorRepository` (string, default:
            "oci://tccr.io/truecharts"): Repository for the TrueCharts operator.
        *   `trueChartsPrometheusOperatorVersion` (string, default: "8.11.1"):
            Chart version for the TrueCharts operator.

2.  **Chart.yaml:**
    *   The `kube-prometheus-stack` dependency condition is updated to
        `"serviceMonitor.enabled, !values.dependencies.useTrueChartsPrometheusOperator"`.
    *   A new dependency for `prometheus-operator` (TrueCharts) is added:
        *   `name: prometheus-operator`
        *   `version: "{{ .Values.dependencies.trueChartsPrometheusOperatorVersion }}"`
        *   `repository: "{{ .Values.dependencies.trueChartsPrometheusOperatorRepository }}"`
        *   `condition: "serviceMonitor.enabled, values.dependencies.useTrueChartsPrometheusOperator"`

This provides you with more flexibility in choosing your Prometheus Operator stack while using the iperf3-monitor chart.