### PR TITLE
Fix: Use dependencies scope for truecharts prometheus-operator

### DIFF
--- a/charts/iperf3-monitor/Chart.yaml
+++ b/charts/iperf3-monitor/Chart.yaml
@@ -27,8 +27,8 @@ dependencies:
   - name: kube-prometheus-stack # Example dependency if you package the whole stack
     version: ">=30.0.0" # Specify a compatible version range
     repository: https://prometheus-community.github.io/helm-charts
-    condition: "serviceMonitor.enabled, !values.dependencies.useTrueChartsPrometheusOperator"
+    condition: "serviceMonitor.enabled, !dependencies.useTrueChartsPrometheusOperator"
   - name: prometheus-operator
-    version: "{{ .Values.dependencies.trueChartsPrometheusOperatorVersion }}"
-    repository: "{{ .Values.dependencies.trueChartsPrometheusOperatorRepository }}"
-    condition: "serviceMonitor.enabled, values.dependencies.useTrueChartsPrometheusOperator"
+    version: ">={{ dependencies.trueChartsPrometheusOperatorVersion }}"
+    repository: "{{ dependencies.trueChartsPrometheusOperatorRepository }}"
+    condition: "serviceMonitor.enabled, dependencies.useTrueChartsPrometheusOperator"


### PR DESCRIPTION
Fixes an issue where truecharts prometheus operator version and repository values where not accessible because they were not under the `dependencies` scope.