### PR TITLE
Fix(exporter): Use namespaced pod listing for iperf server discovery

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -92,16 +92,18 @@ def discover_iperf_servers():
 
         logging.info(f"Discovering iperf3 servers with label '{label_selector}' in namespace '{namespace}'")
 
-        ret = v1.list_pod_for_all_namespaces(label_selector=label_selector, watch=False)
+        # Use list_namespaced_pod to query only the specified namespace
+        ret = v1.list_namespaced_pod(namespace=namespace, label_selector=label_selector, watch=False)
 
         servers = []
         for item in ret.items:
+            # No need to filter by namespace here as the API call is already namespaced
             if item.status.pod_ip and item.status.phase == 'Running':
                 servers.append({
                     'ip': item.status.pod_ip,
                     'node_name': item.spec.node_name # Node where the iperf server pod is running
                 })
-        logging.info(f"Discovered {len(servers)} iperf3 server pods.")
+        logging.info(f"Discovered {len(servers)} iperf3 server pods in namespace '{namespace}'.")
         return servers
     except config.ConfigException as e:
         logging.error(f"Kubernetes config error: {e}. Is the exporter running in a cluster with RBAC permissions?")


### PR DESCRIPTION
- Modified `exporter/exporter.py` to use `list_namespaced_pod()` instead of `list_pod_for_all_namespaces()`. This resolves the RBAC error where the exporter was incorrectly requesting cluster-scoped pod listing permissions.
- The exporter now correctly lists pods only within the namespace specified by the `IPERF_SERVER_NAMESPACE` environment variable.

- Reverted Helm chart RBAC templates (`charts/iperf3-monitor/templates/rbac.yaml`) and `values.yaml` to their simpler, original state. The previous parameterization of `serviceAccount.namespace` is no longer needed, as the primary fix is in the exporter code.

The Helm chart should be deployed into the same namespace where the `iperf3-monitor` ServiceAccount resides and where iperf3 server pods are located. The `IPERF_SERVER_NAMESPACE` environment variable for the exporter pod must be set to this namespace.