### PR TITLE
Fix: Align exporter labels, image tags, and build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            # This ensures that for a git tag like "v0.1.0",
+            # an image tag "0.1.0" is generated.
+            # It will also generate "latest" for the most recent semver tag.
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ Thumbs.db
 # Helm
 !charts/iperf3-monitor/.helmignore
 charts/iperf3-monitor/charts/
+
+# Rendered Kubernetes manifests (for local testing)
+rendered-manifests.yaml
+rendered-manifests-updated.yaml

--- a/charts/iperf3-monitor/templates/exporter-controller.yaml
+++ b/charts/iperf3-monitor/templates/exporter-controller.yaml
@@ -72,12 +72,23 @@ Proceed with modifications only if the exporter controller is defined.
   {{- /*
   Ensure the container image tag is set, defaulting to Chart.AppVersion if empty,
   as the common library validation requires it during 'helm template'.
+
+  NOTE: BJW-S common library typically handles defaulting image.tag to Chart.appVersion
+  if image.tag is empty or null in values. The custom logic below prepending "v"
+  is specific to this chart and might be redundant if the common library's default
+  is preferred. For now, we keep it as it was the reason for previous errors if tag was not set.
+  However, if common library handles it, this block could be removed and image.tag in values.yaml set to "" or null.
+  Forcing the tag to be set (even if to chart.appVersion) ensures the common library doesn't complain.
+  The issue encountered during `helm template` earlier (empty output) was resolved by
+  explicitly setting the tag (e.g. via --set or by ensuring values.yaml has it).
+  The common library's internal validation likely needs *a* tag to be present in the values passed to it,
+  even if that tag is derived from AppVersion. This block ensures that.
   */}}
   {{- $exporterContainerCfg := get $exporterControllerConfig.containers "exporter" -}}
   {{- if $exporterContainerCfg -}}
     {{- if not $exporterContainerCfg.image.tag -}}
       {{- if $chart.AppVersion -}}
-        {{- $_ := set $exporterContainerCfg.image "tag" (printf "v%s" $chart.AppVersion) -}}
+        {{- $_ := set $exporterContainerCfg.image "tag" (printf "%s" $chart.AppVersion) -}} # Removed "v" prefix
       {{- else -}}
         {{- fail (printf "Error: Container image tag is not specified for controller '%s', container '%s', and Chart.AppVersion is also empty." $exporterControllerKey "exporter") -}}
       {{- end -}}

--- a/charts/iperf3-monitor/values.yaml
+++ b/charts/iperf3-monitor/values.yaml
@@ -45,7 +45,8 @@ controllers:
       # -- Annotations for the exporter pod.
       annotations: {}
       # -- Labels for the exporter pod.
-      labels: {} # The common library will add its own default labels.
+      labels:
+        app.kubernetes.io/component: exporter # Ensure pods get the component label for service selection
       # -- Node selector for scheduling exporter pods.
       nodeSelector: {}
       # -- Tolerations for scheduling exporter pods.


### PR DESCRIPTION
- Helm Chart:
  - Added `app.kubernetes.io/component: exporter` to the exporter pod labels via `values.yaml` to match the service selector.
  - Updated image tag defaulting in `exporter-controller.yaml` to use `Chart.appVersion` directly (e.g., "0.1.0" instead of "v0.1.0").

- Build Process (`.github/workflows/release.yml`):
  - Configured `docker/metadata-action` to ensure image tags are generated without a 'v' prefix (e.g., "0.1.0" from Git tag "v0.1.0"). This aligns the published image tags with the Helm chart's updated image tag references.

- Repository:
  - Added `rendered-manifests.yaml` and `rendered-manifests-updated.yaml` to `.gitignore`.